### PR TITLE
Update with Decidim v0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 = Changelog
 
+== 0.1.19 PATCH (01/03/2022)
+- Fix compatibility with Decidim 0.25.2
+
 == 0.1.18 PATCH (19/01/2022)
 - Security fixes:
 - nokogiri: GHSA-2rr5-8q37-2w7h

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-members (0.1.18)
+    decidim-members (0.1.19)
       decidim-core (>= 0.23.0)
       nokogiri (>= 1.12.5)
       pg_search (>= 2.1.4)

--- a/app/decorators/decidim/user_decorator.rb
+++ b/app/decorators/decidim/user_decorator.rb
@@ -3,7 +3,7 @@
 # This decorator adds required associations between Decidim::User
 require_dependency 'decidim/user'
 Decidim::User.class_eval do
-  include PgSearch
+  include PgSearch::Model
 
   pg_search_scope :search_by_name_like, against: %i[name nickname],
                                         using: {

--- a/lib/decidim/members/version.rb
+++ b/lib/decidim/members/version.rb
@@ -2,6 +2,6 @@
 
 module Decidim
   module Members
-    VERSION = '0.1.18'
+    VERSION = '0.1.19'
   end
 end


### PR DESCRIPTION
Fix compatibility with Decidim 0.25.2: there is an error when use it with an application with 0.25 version with Postgres.

In user_decorator `include PgSearch` is changed by `include PgSearch::Model`.

